### PR TITLE
Simplified transitionMatrixFromSOAPClassification, closes #10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - `getXYZfromTrajGroup` now accept IO objects as inputs
 - **WARNING**: broken interface for `getXYZfromTrajGroup`, now it needs 3 inputs and the first is a file-like object
 - `saveXYZfromTrajGroup` and `getXYZfromTrajGroup` now can export comments per frames
+- `transitionMatrixFromSOAPClassification` now creates matrix with shape  `(n,n)` and no more `(n+1,n+1)`, where `n` is the lenght of the legend. The user will now need to address the errors in classification, if needed
 
 ## Changes From 0.0.2a
 

--- a/src/SOAPify/SOAPTransitions.py
+++ b/src/SOAPify/SOAPTransitions.py
@@ -10,6 +10,7 @@ def transitionMatrixFromSOAPClassification(
         The matrix is organized in the following way:
         for each atom in each frame we increment by one the cell whose row is the
         state at the frame `n-stride` and the column is the state at the frame `n`
+        If the classification includes an error with a `-1` values the user should add an 'error' class in the legend
 
     Args:
         data (SOAPclassification): the results of the soapClassification from :func:`classifyWithSOAP`
@@ -20,8 +21,8 @@ def transitionMatrixFromSOAPClassification(
     """
     nframes = len(data.references)
     nat = len(data.references[0])
-    # +1 in case of errors
-    nclasses = len(data.legend) + 1
+
+    nclasses = len(data.legend)
     transMat = np.zeros((nclasses, nclasses), np.dtype(float))
 
     for frameID in range(stride, nframes, 1):
@@ -51,7 +52,7 @@ def normalizeMatrix(transMat: "np.ndarray[float]") -> "np.ndarray[float]":
 
 
 def transitionMatrixFromSOAPClassificationNormalized(
-    data: SOAPclassification, stride: int = 1
+    data: SOAPclassification, stride: int = 1, withErrors=False
 ) -> "np.ndarray[float]":
     """Generates the normalized matrix of the transitions from a :func:`classifyWithSOAP` and normalize it
 
@@ -68,5 +69,5 @@ def transitionMatrixFromSOAPClassificationNormalized(
     Returns:
         np.ndarray[float]: the normalized matrix of the transitions
     """
-    transMat = transitionMatrixFromSOAPClassification(data, stride)
+    transMat = transitionMatrixFromSOAPClassification(data, stride, withErrors)
     return normalizeMatrix(transMat)

--- a/test/test_SOAPify.py
+++ b/test/test_SOAPify.py
@@ -55,12 +55,13 @@ def test_concatenationOfSOAPreferences():
     assert_array_equal(b.spectra[0], c.spectra[2])
     assert_array_equal(b.spectra[1], c.spectra[3])
 
+
 def test_concatenationOfSOAPreferencesLonger():
     a = SOAPReferences(["a", "b"], [[0, 0], [1, 1]], 8, 8)
     b = SOAPReferences(["c", "d"], [[2, 2], [3, 3]], 8, 8)
     d = SOAPReferences(["e", "f"], [[4, 4], [5, 5]], 8, 8)
-    c = SOAPify.mergeReferences(a, b,d)
-    assert len(c.names) == (len(a)+len(b)+len(d))
+    c = SOAPify.mergeReferences(a, b, d)
+    assert len(c.names) == (len(a) + len(b) + len(d))
     assert c.spectra.shape == (6, 2)
     assert_array_equal(a.spectra[0], c.spectra[0])
     assert_array_equal(a.spectra[1], c.spectra[1])
@@ -68,6 +69,7 @@ def test_concatenationOfSOAPreferencesLonger():
     assert_array_equal(b.spectra[1], c.spectra[3])
     assert_array_equal(d.spectra[0], c.spectra[4])
     assert_array_equal(d.spectra[1], c.spectra[5])
+
 
 def test_fillSOAPVectorFromdscribeSingleVector():
     nmax = 4
@@ -101,3 +103,60 @@ def test_fillSOAPVectorFromdscribeArrayOfVector():
                     assert c[l, n, np] == a[i, limited]
                     assert c[l, np, n] == a[i, limited]
                     limited += 1
+
+
+def test_transitionMatrixWithNoError():
+    data = SOAPify.SOAPclassification(
+        [],
+        numpy.array(
+            [
+                [0, 0, 1, 2, 2, 1],
+                [0, 0, 2, 2, 2, 2],
+                [0, 0, 2, 2, 2, 1],
+                [0, 0, 2, 2, 2, 2],
+            ]
+        ),
+        ["1", "2", "3"],
+    )
+    tmat = SOAPify.transitionMatrixFromSOAPClassification(data)
+    assert tmat.shape[0] == len(data.legend)
+    # hand calculated:
+    assert_array_equal(
+        tmat,
+        numpy.array(
+            [
+                [6, 0, 0],
+                [0, 0, 3],
+                [0, 1, 8],
+            ]
+        ),
+    )
+
+
+def test_transitionMatrixWithError():
+    data = SOAPify.SOAPclassification(
+        [],
+        numpy.array(
+            [
+                [0, 0, 1, 2, 2, 1],
+                [0, 0, 2, 2, 2, 2],
+                [0, 0, 2, 2, 2, 1],
+                [0, 0, 2, 2, 2, -1],
+            ]
+        ),
+        ["1", "2", "3", "Errors"],
+    )
+    tmat = SOAPify.transitionMatrixFromSOAPClassification(data)
+    assert tmat.shape[0] == len(data.legend)
+    # hand calculated:
+    assert_array_equal(
+        tmat,
+        numpy.array(
+            [
+                [6, 0, 0, 0],
+                [0, 0, 2, 1],
+                [0, 1, 8, 0],
+                [0, 0, 0, 0],
+            ]
+        ),
+    )


### PR DESCRIPTION
I have slightly changed the behavior of the transition matrices creator:
now the user must explicitly put in the legend the error category if needed